### PR TITLE
feat(dataset): ajouter 119 questions couvrant les 8 parties adultes des RFE

### DIFF
--- a/datasets/sfar_antibioprophylaxie/benchmark.json
+++ b/datasets/sfar_antibioprophylaxie/benchmark.json
@@ -890,7 +890,7 @@
       "id": "Q120",
       "titre": "Cataracte molécule",
       "type": "mcq",
-      "question": "Quelle molécule est recommandée pour l'antibioprophylaxie de la chirurgie de la cataracte ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la chirurgie de la cataracte ?",
       "réponse": "B",
       "choices": {
         "A": "Céfazoline IV",
@@ -968,7 +968,7 @@
       "id": "Q126",
       "titre": "Hystérectomie voie d'abord et molécule",
       "type": "mcq",
-      "question": "Quelle molécule est recommandée pour l'antibioprophylaxie d'une hystérectomie totale par voie coelioscopique (avec annexectomie) ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une hystérectomie totale par voie coelioscopique (avec annexectomie) ?",
       "réponse": "B",
       "choices": {
         "A": "Céfazoline",
@@ -1049,7 +1049,7 @@
       "question": "Une cholécystectomie élective par coelioscopie est programmée. Dans quel cas une antibioprophylaxie est-elle recommandée ?",
       "réponse": "B",
       "choices": {
-        "A": "Chez un patient de moins de 60 ans, sans comorbidité, pour vésicule lithiasique symptomatique sans cholecystite",
+        "A": "Chez un patient de moins de 60 ans, sans comorbidité, pour vésicule lithiasique symptomatique sans cholécystite",
         "B": "Chez un patient avec ictère et calcul de la voie biliaire principale",
         "C": "Une antibioprophylaxie est toujours recommandée quelle que soit la situation",
         "D": "Une antibioprophylaxie n'est jamais recommandée pour la voie coelioscopique"

--- a/datasets/sfar_antibioprophylaxie/benchmark.json
+++ b/datasets/sfar_antibioprophylaxie/benchmark.json
@@ -9,7 +9,7 @@
       "id": "Q01",
       "titre": "PTH standard",
       "type": "open",
-      "question": "Quelle molécule d'antibioprophylaxie recommandez-vous pour une prothèse totale de hanche ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une prothèse totale de hanche ?",
       "réponse": "Céfazoline"
     },
     {
@@ -23,21 +23,21 @@
       "id": "Q03",
       "titre": "PTG allergie bêtalactamines",
       "type": "open",
-      "question": "Un patient allergique aux bêtalactamines doit bénéficier d'une prothèse de genou. Quelle molécule en première intention ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une prothèse totale de genou chez un patient allergique aux bêtalactamines ?",
       "réponse": "Clindamycine"
     },
     {
       "id": "Q04",
       "titre": "PTH voie antérieure allergie",
       "type": "open",
-      "question": "Quelle molécule d'antibioprophylaxie pour une prothèse de hanche par voie antérieure chez un patient allergique aux bêtalactamines ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une prothèse de hanche par voie antérieure chez un patient allergique aux bêtalactamines ?",
       "réponse": "Vancomycine"
     },
     {
       "id": "Q05",
       "titre": "Fracture ouverte Gustilo 2",
       "type": "open",
-      "question": "Quelle molécule d'antibioprophylaxie pour une fracture ouverte de jambe Gustilo 2 ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une fracture ouverte de jambe Gustilo 2 ?",
       "réponse": "Amoxicilline/Clavulanate"
     },
     {
@@ -51,28 +51,28 @@
       "id": "Q07",
       "titre": "Arthrodèse lombaire instrumentée",
       "type": "open",
-      "question": "Quelle molécule d'antibioprophylaxie pour une arthrodèse lombaire instrumentée en un temps ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une arthrodèse lombaire instrumentée en un temps ?",
       "réponse": "Céfazoline"
     },
     {
       "id": "Q08",
       "titre": "Parage morsure",
       "type": "open",
-      "question": "Quelle molécule d'antibioprophylaxie pour le parage chirurgical d'une morsure ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour le parage chirurgical d'une morsure ?",
       "réponse": "Amoxicilline/Clavulanate"
     },
     {
       "id": "Q09",
       "titre": "Écrasement main > 2h",
       "type": "open",
-      "question": "Quelle molécule d'antibioprophylaxie pour un écrasement complexe de la main nécessitant une chirurgie de plus de 2 heures ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour un écrasement complexe de la main nécessitant une chirurgie de plus de 2 heures ?",
       "réponse": "Amoxicilline/Clavulanate"
     },
     {
       "id": "Q10",
       "titre": "Plaie agricole cuisse",
       "type": "open",
-      "question": "Quelle molécule d'antibioprophylaxie pour une plaie de cuisse par accident agricole, susceptible d'être contaminée par des germes telluriques ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une plaie de cuisse par accident agricole, susceptible d'être contaminée par des germes telluriques ?",
       "réponse": "Amoxicilline/Clavulanate"
     },
     {
@@ -86,7 +86,7 @@
       "id": "Q12",
       "titre": "Fracture ouverte Gustilo 3 allergie",
       "type": "open",
-      "question": "Un patient allergique aux pénicillines présente une fracture ouverte Gustilo 3. Quelle(s) molécule(s) d'antibioprophylaxie ?",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une fracture ouverte Gustilo 3 chez un patient allergique aux pénicillines ?",
       "réponse": "Clindamycine + Gentamicine"
     },
     {
@@ -98,6 +98,692 @@
     },
     {
       "id": "Q14",
+      "titre": "Craniotomie standard",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une craniotomie ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q15",
+      "titre": "Biopsie cérébrale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une biopsie cérébrale ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q16",
+      "titre": "DVE",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la pose d'une dérivation ventriculaire externe (DVE) ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q17",
+      "titre": "DVP",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la pose d'une dérivation ventriculo-péritonéale (DVP) ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q18",
+      "titre": "Plaie cranio-cérébrale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une plaie cranio-cérébrale pénétrante ?",
+      "réponse": "Amoxicilline/Clavulanate"
+    },
+    {
+      "id": "Q19",
+      "titre": "Fracture base du crâne sans otorrhée",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une fracture de la base du crâne sans otorrhée ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q20",
+      "titre": "Fracture base du crâne avec otorrhée",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une fracture de la base du crâne avec otorrhée ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q21",
+      "titre": "Pose stimulateur cérébral",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la pose d'une électrode de stimulation cérébrale profonde ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q22",
+      "titre": "Embolisation anévrysme cérébral",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour l'embolisation d'un anévrysme cérébral ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q23",
+      "titre": "Craniotomie allergie bêtalactamines",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une craniotomie chez un patient allergique aux bêtalactamines ?",
+      "réponse": "Clindamycine"
+    },
+    {
+      "id": "Q24",
+      "titre": "Plaie cranio-cérébrale allergie pénicillines",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une plaie cranio-cérébrale chez un patient allergique aux pénicillines ?",
+      "réponse": "Triméthoprime/Sulfaméthoxazole"
+    },
+    {
+      "id": "Q25",
+      "titre": "Amygdalectomie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une amygdalectomie ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q26",
+      "titre": "Thyroïdectomie totale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une thyroïdectomie totale ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q27",
+      "titre": "Chirurgie sinusienne polypose",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie sinusienne de polypose nasale ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q28",
+      "titre": "Laryngectomie totale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une laryngectomie totale (chirurgie carcinologique ORL sans reconstruction) ?",
+      "réponse": "Amoxicilline/Clavulanate"
+    },
+    {
+      "id": "Q29",
+      "titre": "Implant cochléaire",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la pose d'un implant cochléaire ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q30",
+      "titre": "Trachéotomie chirurgicale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une trachéotomie chirurgicale ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q31",
+      "titre": "Trachéotomie percutanée",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une trachéotomie percutanée ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q32",
+      "titre": "Chirurgie cataracte",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie de la cataracte ?",
+      "réponse": "Céfuroxime"
+    },
+    {
+      "id": "Q33",
+      "titre": "Chirurgie glaucome",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie du glaucome ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q34",
+      "titre": "Traumatisme globe ouvert",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour un traumatisme à globe ouvert ?",
+      "réponse": "Vancomycine + Ceftazidime"
+    },
+    {
+      "id": "Q35",
+      "titre": "Chirurgie strabisme",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie du strabisme ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q36",
+      "titre": "Extraction dent incluse",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour l'extraction d'une dent incluse ?",
+      "réponse": "Amoxicilline"
+    },
+    {
+      "id": "Q37",
+      "titre": "Fracture mandibule",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une fracture ouverte de mandibule ?",
+      "réponse": "Amoxicilline/Clavulanate"
+    },
+    {
+      "id": "Q38",
+      "titre": "Chirurgie orthognatique",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie orthognatique ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q39",
+      "titre": "Carcinologique cervico-faciale allergie bêtalactamines",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie carcinologique cervico-faciale avec lambeau chez un patient allergique aux bêtalactamines ?",
+      "réponse": "Clindamycine + Gentamicine"
+    },
+    {
+      "id": "Q40",
+      "titre": "Remplacement valvulaire sous CEC",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour un remplacement valvulaire aortique sous circulation extracorporelle (CEC) ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q41",
+      "titre": "TAVI",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la pose d'une bioprothèse de valve aortique par voie transcutanée (TAVI) ?",
+      "réponse": "Amoxicilline/Clavulanate"
+    },
+    {
+      "id": "Q42",
+      "titre": "Pose pacemaker",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour l'implantation d'un stimulateur cardiaque (pacemaker) ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q43",
+      "titre": "Ablation FA par cathéter",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une ablation de fibrillation atriale par cathéter (radiofréquence), chez un patient n'ayant pas de prothèse intracardiaque déjà implantée ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q44",
+      "titre": "ECMO percutanée",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la mise en place d'une ECMO percutanée (sans abord chirurgical) ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q45",
+      "titre": "Endartériectomie carotidienne sans matériel",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une endartériectomie carotidienne sans mise en place de matériel ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q46",
+      "titre": "Amputation de membre",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une amputation de membre (hors contexte septique) ?",
+      "réponse": "Amoxicilline/Clavulanate"
+    },
+    {
+      "id": "Q47",
+      "titre": "Chirurgie varices sans scarpa",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie des varices sans abord chirurgical du scarpa ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q48",
+      "titre": "Drainage thoracique",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la pose d'un drain thoracique ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q49",
+      "titre": "Médiastinoscopie avec biopsies",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une médiastinoscopie avec biopsies ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q50",
+      "titre": "Fibroscopie bronchique",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une fibroscopie bronchique avec lavage broncho-alvéolaire ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q51",
+      "titre": "Pose prothèse mammaire",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une augmentation mammaire avec pose d'implants siliconés ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q52",
+      "titre": "Tumorectomie mammaire sans curage",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une tumorectomie mammaire sans curage ganglionnaire ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q53",
+      "titre": "Mastectomie sans reconstruction",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une mastectomie sans reconstruction mammaire ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q54",
+      "titre": "Rhinoplastie sans greffe cartilage",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une septo-rhinoplastie sans greffe de cartilage ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q55",
+      "titre": "Lipoaspiration",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une lipoaspiration sous anesthésie générale ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q56",
+      "titre": "Blépharoplastie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une blépharoplastie ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q57",
+      "titre": "Lambeau libre microchirurgical",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une reconstruction par lambeau libre microchirurgical ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q58",
+      "titre": "Greffe cutanée hors brûlure",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une greffe cutanée (hors patient brûlé) ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q59",
+      "titre": "Vaginoplastie affirmation de genre",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une vaginoplastie dans le cadre d'une chirurgie d'affirmation de genre ?",
+      "réponse": "Amoxicilline/Clavulanate"
+    },
+    {
+      "id": "Q60",
+      "titre": "Chondro-laryngoplastie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chondro-laryngoplastie par cervicotomie ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q61",
+      "titre": "Tumorectomie mammaire avec curage axillaire",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une tumorectomie mammaire avec curage axillaire ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q62",
+      "titre": "Mastoplastie de réduction",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une mastoplastie bilatérale de réduction ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q63",
+      "titre": "Chirurgie du mamelon",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie du mamelon ou de la plaque aréolo-mamelonnaire ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q64",
+      "titre": "Coelioscopie diagnostique gynécologique",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une coelioscopie diagnostique en gynécologie ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q65",
+      "titre": "Annexectomie par coelioscopie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une annexectomie par voie coelioscopique ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q66",
+      "titre": "Résection endométriose avec atteinte rectale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une résection de lésions endométriosiques avec atteinte rectale par coelioscopie ?",
+      "réponse": "Céfazoline + Métronidazole"
+    },
+    {
+      "id": "Q67",
+      "titre": "Hystérectomie totale par laparotomie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une hystérectomie totale sans annexectomie par laparotomie ?",
+      "réponse": "Céfoxitine"
+    },
+    {
+      "id": "Q68",
+      "titre": "Hystérectomie subtotale avec annexectomie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une hystérectomie subtotale avec annexectomie (sans temps vaginal) ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q69",
+      "titre": "Conisation col utérin",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une conisation du col utérin ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q70",
+      "titre": "Hystéroscopie diagnostique",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une hystéroscopie diagnostique ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q71",
+      "titre": "Biopsie de l'endomètre",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une biopsie de l'endomètre par hystéroscopie ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q72",
+      "titre": "Chirurgie du prolapsus",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une hystéropexie (chirurgie du prolapsus) ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q73",
+      "titre": "Vulvectomie avec curage inguinal",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une vulvectomie partielle avec curage lymphonodal inguinal unilatéral ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q74",
+      "titre": "Nymphoplastie de réduction",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une nymphoplastie de réduction ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q75",
+      "titre": "Césarienne",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une césarienne programmée ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q76",
+      "titre": "Cerclage col utérin grossesse",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour un cerclage du col de l'utérus au cours de la grossesse par voie transvaginale ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q77",
+      "titre": "Révision utérine",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une révision de la cavité utérine après l'accouchement ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q78",
+      "titre": "Tamponnement utérin hémorragie obstétricale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la pose d'un tamponnement intra-utérin pour hémorragie obstétricale ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q79",
+      "titre": "IVG premier trimestre",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une interruption volontaire de grossesse par aspiration au premier trimestre ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q80",
+      "titre": "Ponction ovocytes PMA",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour un prélèvement d'ovocytes par voie transvaginale avec échoguidage (PMA) ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q81",
+      "titre": "Oesophagectomie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une oesophagectomie ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q82",
+      "titre": "Sleeve gastrectomie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une sleeve gastrectomie (chirurgie bariatrique) ?",
+      "réponse": "Céfoxitine"
+    },
+    {
+      "id": "Q83",
+      "titre": "Anneau gastrique",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la mise en place d'un anneau gastrique (chirurgie bariatrique) ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q84",
+      "titre": "Résection intestin grêle",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une résection de l'intestin grêle par laparotomie ?",
+      "réponse": "Céfoxitine"
+    },
+    {
+      "id": "Q85",
+      "titre": "Appendicectomie programmée",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une appendicectomie programmée ?",
+      "réponse": "Céfoxitine"
+    },
+    {
+      "id": "Q86",
+      "titre": "Hémorroïdes",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie des hémorroïdes ?",
+      "réponse": "Métronidazole"
+    },
+    {
+      "id": "Q87",
+      "titre": "Cholécystectomie coelioscopique haut risque",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une cholécystectomie élective par coelioscopie chez un patient de 82 ans ictérique, présentant un calcul dans la voie biliaire principale ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q88",
+      "titre": "Cholécystectomie par laparotomie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une cholécystectomie par laparotomie ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q89",
+      "titre": "Kyste hydatique du foie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie d'un kyste hydatique du foie ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q90",
+      "titre": "Splénectomie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une splénectomie programmée par laparotomie ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q91",
+      "titre": "Pancréatectomie gauche",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une pancréatectomie gauche avec conservation de la rate ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q92",
+      "titre": "DPC sans drainage biliaire préopératoire",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une duodéno-pancréatectomie céphalique (DPC) sans geste de drainage biliaire préopératoire ?",
+      "réponse": "Céfoxitine"
+    },
+    {
+      "id": "Q93",
+      "titre": "DPT avec drainage biliaire préopératoire",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une duodéno-pancréatectomie totale (DPT) pour ampullome avec antécédent de drainage biliaire ?",
+      "réponse": "Pipéracilline/Tazobactam"
+    },
+    {
+      "id": "Q94",
+      "titre": "Transplantation hépatique",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une transplantation hépatique ?",
+      "réponse": "Céfoxitine"
+    },
+    {
+      "id": "Q95",
+      "titre": "Hernie inguinale avec prothèse",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une cure de hernie inguinale avec pose de prothèse par coelioscopie ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q96",
+      "titre": "Hernie aine sans prothèse",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une cure de hernie de l'aine sans prothèse ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q97",
+      "titre": "Gastrostomie percutanée",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la pose d'une gastrostomie par voie transcutanée avec guidage endoscopique ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q98",
+      "titre": "Coloscopie avec biopsie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une coloscopie diagnostique avec biopsie ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q99",
+      "titre": "CPRE avec drainage complet",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une CPRE avec extraction de calculs biliaires et drainage biliaire complet satisfaisant ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q100",
+      "titre": "Embolisation hépatique",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chimio-embolisation hépatique ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q101",
+      "titre": "RTUP",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une résection trans-urétrale de prostate (RTUP) ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q102",
+      "titre": "Prostatectomie totale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une prostatectomie totale ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q103",
+      "titre": "Biopsie prostate transrectale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour des biopsies de prostate par voie transrectale ?",
+      "réponse": "Fosfomycine-trométamol"
+    },
+    {
+      "id": "Q104",
+      "titre": "Biopsie prostate transpérinéale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour des biopsies de prostate par voie transpérinéale ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q105",
+      "titre": "Cystoscopie diagnostique",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une cystoscopie diagnostique ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q106",
+      "titre": "Cystectomie sustrigonale",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une cystectomie sustrigonale totale ?",
+      "réponse": "Céfoxitine"
+    },
+    {
+      "id": "Q107",
+      "titre": "Prothèse pénienne",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour la pose d'une prothèse pénienne ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q108",
+      "titre": "Chirurgie scrotale sans prothèse",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une chirurgie scrotale sans prothèse ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q109",
+      "titre": "Urétéroscopie",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une urétéroscopie diagnostique ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q110",
+      "titre": "Lithotritie extra-corporelle",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une lithotritie extra-corporelle ?",
+      "réponse": "Pas d'antibioprophylaxie"
+    },
+    {
+      "id": "Q111",
+      "titre": "Néphrolithotomie percutanée",
+      "type": "open",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une néphrolithotomie percutanée ?",
+      "réponse": "Céfazoline"
+    },
+    {
+      "id": "Q112",
       "titre": "PTG première intention",
       "type": "mcq",
       "question": "Quelle molécule est recommandée en première intention pour l'antibioprophylaxie d'une prothèse totale de genou ?",
@@ -110,7 +796,7 @@
       }
     },
     {
-      "id": "Q15",
+      "id": "Q113",
       "titre": "Intervention sans ABP",
       "type": "mcq",
       "question": "Parmi ces interventions, laquelle ne nécessite PAS d'antibioprophylaxie ?",
@@ -123,7 +809,7 @@
       }
     },
     {
-      "id": "Q16",
+      "id": "Q114",
       "titre": "PTG allergie alternative",
       "type": "mcq",
       "question": "En cas d'allergie aux bêtalactamines, quelle est l'alternative de première intention pour l'antibioprophylaxie d'une prothèse de genou ?",
@@ -136,7 +822,7 @@
       }
     },
     {
-      "id": "Q17",
+      "id": "Q115",
       "titre": "Seuil Gustilo changement molécule",
       "type": "mcq",
       "question": "À partir de quel stade de Gustilo la molécule d'antibioprophylaxie change-t-elle (passage de la Céfazoline à l'Amoxicilline/Clavulanate) ?",
@@ -149,7 +835,7 @@
       }
     },
     {
-      "id": "Q18",
+      "id": "Q116",
       "titre": "Plaie jardinage main",
       "type": "mcq",
       "question": "Un patient se présente avec une plaie de la main par accident de jardinage, susceptible de contamination tellurique. Quelle est la recommandation ?",
@@ -159,6 +845,240 @@
         "B": "Amoxicilline/Clavulanate 2g IVL",
         "C": "Pas d'antibioprophylaxie recommandée",
         "D": "Clindamycine 900mg IVL"
+      }
+    },
+    {
+      "id": "Q117",
+      "titre": "DVE vs DVP",
+      "type": "mcq",
+      "question": "Parmi ces actes neurochirurgicaux, lequel nécessite une antibioprophylaxie ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Dérivation ventriculaire externe (DVE)",
+        "B": "Biopsie cérébrale",
+        "C": "Dérivation ventriculo-péritonéale (DVP)",
+        "D": "Angiographie des artères cérébrales"
+      }
+    },
+    {
+      "id": "Q118",
+      "titre": "Rachis avec vs sans matériel",
+      "type": "mcq",
+      "question": "Pour la chirurgie du rachis, dans quel cas une antibioprophylaxie est-elle recommandée ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Laminectomie sans pose de matériel",
+        "B": "Chirurgie du canal lombaire étroit",
+        "C": "Arthrodèse instrumentée en un temps",
+        "D": "Ablation de matériel du rachis"
+      }
+    },
+    {
+      "id": "Q119",
+      "titre": "ORL sans ABP",
+      "type": "mcq",
+      "question": "Parmi ces interventions ORL, laquelle ne nécessite PAS d'antibioprophylaxie ?",
+      "réponse": "B",
+      "choices": {
+        "A": "Pose d'implant cochléaire",
+        "B": "Amygdalectomie",
+        "C": "Laryngectomie totale",
+        "D": "Trachéotomie chirurgicale"
+      }
+    },
+    {
+      "id": "Q120",
+      "titre": "Cataracte molécule",
+      "type": "mcq",
+      "question": "Quelle molécule est recommandée pour l'antibioprophylaxie de la chirurgie de la cataracte ?",
+      "réponse": "B",
+      "choices": {
+        "A": "Céfazoline IV",
+        "B": "Céfuroxime intracamérulaire",
+        "C": "Vancomycine intravitréenne",
+        "D": "Moxifloxacine en collyre"
+      }
+    },
+    {
+      "id": "Q121",
+      "titre": "Trachéotomie chirurgicale vs percutanée",
+      "type": "mcq",
+      "question": "Concernant l'antibioprophylaxie des trachéotomies, quelle affirmation est correcte ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Une antibioprophylaxie est recommandée pour les deux types de trachéotomie",
+        "B": "Aucune antibioprophylaxie n'est recommandée, quel que soit le type",
+        "C": "Une antibioprophylaxie est recommandée uniquement pour la trachéotomie chirurgicale",
+        "D": "Une antibioprophylaxie est recommandée uniquement pour la trachéotomie percutanée"
+      }
+    },
+    {
+      "id": "Q122",
+      "titre": "Lobectomie pulmonaire molécule",
+      "type": "mcq",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une lobectomie pulmonaire par thoracotomie ?",
+      "réponse": "D",
+      "choices": {
+        "A": "Amoxicilline/Clavulanate uniquement",
+        "B": "Céfazoline uniquement",
+        "C": "Céfuroxime uniquement",
+        "D": "Amoxicilline/Clavulanate, Céfazoline ou Céfuroxime (au choix)"
+      }
+    },
+    {
+      "id": "Q123",
+      "titre": "Carotide avec vs sans matériel",
+      "type": "mcq",
+      "question": "Concernant l'antibioprophylaxie de la chirurgie carotidienne, quelle affirmation est correcte ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Une antibioprophylaxie est toujours recommandée",
+        "B": "Une antibioprophylaxie n'est jamais recommandée",
+        "C": "Une antibioprophylaxie est recommandée uniquement en cas de mise en place de matériel",
+        "D": "Une antibioprophylaxie est recommandée uniquement en cas de reprise chirurgicale"
+      }
+    },
+    {
+      "id": "Q124",
+      "titre": "Chirurgie mammaire et ABP",
+      "type": "mcq",
+      "question": "Parmi ces interventions mammaires, laquelle nécessite une antibioprophylaxie ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Tumorectomie mammaire sans curage",
+        "B": "Mastopexie pour ptose simple",
+        "C": "Mastectomie sans curage ganglionnaire",
+        "D": "Réduction mammaire"
+      }
+    },
+    {
+      "id": "Q125",
+      "titre": "Rhinoplastie avec vs sans greffe",
+      "type": "mcq",
+      "question": "Concernant l'antibioprophylaxie en septo-rhinoplastie, quelle affirmation est correcte ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Une antibioprophylaxie est toujours recommandée",
+        "B": "Une antibioprophylaxie n'est jamais recommandée",
+        "C": "Une antibioprophylaxie est recommandée uniquement en cas de greffe de cartilage",
+        "D": "Une antibioprophylaxie est recommandée uniquement en cas de reprise chirurgicale"
+      }
+    },
+    {
+      "id": "Q126",
+      "titre": "Hystérectomie voie d'abord et molécule",
+      "type": "mcq",
+      "question": "Quelle molécule est recommandée pour l'antibioprophylaxie d'une hystérectomie totale par voie coelioscopique (avec annexectomie) ?",
+      "réponse": "B",
+      "choices": {
+        "A": "Céfazoline",
+        "B": "Céfoxitine",
+        "C": "Amoxicilline/Clavulanate",
+        "D": "Céfuroxime"
+      }
+    },
+    {
+      "id": "Q127",
+      "titre": "Coelioscopie gynécologique sans ABP",
+      "type": "mcq",
+      "question": "Parmi ces interventions gynécologiques par coelioscopie, laquelle ne nécessite PAS d'antibioprophylaxie ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Annexectomie",
+        "B": "Curage pelvien",
+        "C": "Kystectomie ovarienne",
+        "D": "Omentectomie"
+      }
+    },
+    {
+      "id": "Q128",
+      "titre": "Obstétrique césarienne vs cerclage",
+      "type": "mcq",
+      "question": "Concernant l'antibioprophylaxie en obstétrique, quelle affirmation est correcte ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Le cerclage du col utérin nécessite une antibioprophylaxie par céfazoline",
+        "B": "La césarienne programmée ne nécessite pas d'antibioprophylaxie",
+        "C": "La délivrance artificielle nécessite une antibioprophylaxie par céfazoline",
+        "D": "Le curetage post-partum nécessite une antibioprophylaxie par céfoxitine"
+      }
+    },
+    {
+      "id": "Q129",
+      "titre": "Endométriose rectale molécule",
+      "type": "mcq",
+      "question": "Quelle est la recommandation d'antibioprophylaxie pour une résection de lésions endométriosiques avec atteinte rectale ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Céfazoline seule",
+        "B": "Céfoxitine seule",
+        "C": "Céfazoline + Métronidazole",
+        "D": "Amoxicilline/Clavulanate"
+      }
+    },
+    {
+      "id": "Q130",
+      "titre": "Bariatrique anneau vs sleeve",
+      "type": "mcq",
+      "question": "Concernant l'antibioprophylaxie en chirurgie bariatrique, quelle affirmation est correcte ?",
+      "réponse": "B",
+      "choices": {
+        "A": "Anneau gastrique et sleeve gastrectomie utilisent la même molécule",
+        "B": "L'anneau gastrique nécessite de la céfazoline, la sleeve gastrectomie de la céfoxitine",
+        "C": "Aucune chirurgie bariatrique ne nécessite d'antibioprophylaxie",
+        "D": "Toute chirurgie bariatrique nécessite de la céfoxitine"
+      }
+    },
+    {
+      "id": "Q131",
+      "titre": "Colectomie protocole ABP",
+      "type": "mcq",
+      "question": "Quel est le protocole d'antibioprophylaxie recommandé pour une colectomie programmée ?",
+      "réponse": "B",
+      "choices": {
+        "A": "Céfoxitine IV le jour de la chirurgie uniquement",
+        "B": "Tobramycine + Métronidazole per os la veille, puis Céfoxitine IV le jour de la chirurgie",
+        "C": "Amoxicilline/Clavulanate IV le jour de la chirurgie uniquement",
+        "D": "Céfazoline IV le jour de la chirurgie + Métronidazole per os la veille"
+      }
+    },
+    {
+      "id": "Q132",
+      "titre": "Cholécystectomie coelioscopique risque",
+      "type": "mcq",
+      "question": "Une cholécystectomie élective par coelioscopie est programmée. Dans quel cas une antibioprophylaxie est-elle recommandée ?",
+      "réponse": "B",
+      "choices": {
+        "A": "Chez un patient de moins de 60 ans, sans comorbidité, pour vésicule lithiasique symptomatique sans cholecystite",
+        "B": "Chez un patient avec ictère et calcul de la voie biliaire principale",
+        "C": "Une antibioprophylaxie est toujours recommandée quelle que soit la situation",
+        "D": "Une antibioprophylaxie n'est jamais recommandée pour la voie coelioscopique"
+      }
+    },
+    {
+      "id": "Q133",
+      "titre": "Biopsie prostate voie d'abord",
+      "type": "mcq",
+      "question": "Concernant l'antibioprophylaxie des biopsies de prostate, quelle affirmation est correcte ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Les deux voies (transrectale et transpérinéale) nécessitent une antibioprophylaxie",
+        "B": "Aucune des deux voies ne nécessite d'antibioprophylaxie",
+        "C": "Seule la voie transrectale nécessite une antibioprophylaxie (fosfomycine-trométamol)",
+        "D": "Seule la voie transpérinéale nécessite une antibioprophylaxie (céfazoline)"
+      }
+    },
+    {
+      "id": "Q134",
+      "titre": "Hernie inguinale avec vs sans prothèse",
+      "type": "mcq",
+      "question": "Concernant l'antibioprophylaxie de la cure de hernie inguinale, quelle affirmation est correcte ?",
+      "réponse": "C",
+      "choices": {
+        "A": "Une antibioprophylaxie est toujours recommandée, avec ou sans prothèse",
+        "B": "Une antibioprophylaxie n'est jamais recommandée, avec ou sans prothèse",
+        "C": "Une antibioprophylaxie est recommandée uniquement en cas de pose de prothèse",
+        "D": "Une antibioprophylaxie est recommandée uniquement en l'absence de prothèse"
       }
     }
   ]

--- a/datasets/sfar_antibioprophylaxie/benchmark.md
+++ b/datasets/sfar_antibioprophylaxie/benchmark.md
@@ -506,6 +506,192 @@ Pour les QCM, une seule réponse correcte (lettre).
 - **question** : Quelle est la recommandation d'antibioprophylaxie pour un prélèvement d'ovocytes par voie transvaginale avec échoguidage (PMA) ?
 - **réponse** : Pas d'antibioprophylaxie
 
+### Oesophagectomie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une oesophagectomie ?
+- **réponse** : Céfazoline
+
+### Sleeve gastrectomie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une sleeve gastrectomie (chirurgie bariatrique) ?
+- **réponse** : Céfoxitine
+
+### Anneau gastrique
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la mise en place d'un anneau gastrique (chirurgie bariatrique) ?
+- **réponse** : Céfazoline
+
+### Résection intestin grêle
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une résection de l'intestin grêle par laparotomie ?
+- **réponse** : Céfoxitine
+
+### Appendicectomie programmée
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une appendicectomie programmée ?
+- **réponse** : Céfoxitine
+
+### Hémorroïdes
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie des hémorroïdes ?
+- **réponse** : Métronidazole
+
+### Cholécystectomie coelioscopique haut risque
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une cholécystectomie élective par coelioscopie chez un patient de 82 ans ictérique, présentant un calcul dans la voie biliaire principale ?
+- **réponse** : Céfazoline
+
+### Cholécystectomie par laparotomie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une cholécystectomie par laparotomie ?
+- **réponse** : Céfazoline
+
+### Kyste hydatique du foie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie d'un kyste hydatique du foie ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Splénectomie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une splénectomie programmée par laparotomie ?
+- **réponse** : Céfazoline
+
+### Pancréatectomie gauche
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une pancréatectomie gauche avec conservation de la rate ?
+- **réponse** : Céfazoline
+
+### DPC sans drainage biliaire préopératoire
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une duodéno-pancréatectomie céphalique (DPC) sans geste de drainage biliaire préopératoire ?
+- **réponse** : Céfoxitine
+
+### DPT avec drainage biliaire préopératoire
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une duodéno-pancréatectomie totale (DPT) pour ampullome avec antécédent de drainage biliaire ?
+- **réponse** : Pipéracilline/Tazobactam
+
+### Transplantation hépatique
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une transplantation hépatique ?
+- **réponse** : Céfoxitine
+
+### Hernie inguinale avec prothèse
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une cure de hernie inguinale avec pose de prothèse par coelioscopie ?
+- **réponse** : Céfazoline
+
+### Hernie aine sans prothèse
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une cure de hernie de l'aine sans prothèse ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Gastrostomie percutanée
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la pose d'une gastrostomie par voie transcutanée avec guidage endoscopique ?
+- **réponse** : Céfazoline
+
+### Coloscopie avec biopsie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une coloscopie diagnostique avec biopsie ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### CPRE avec drainage complet
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une CPRE avec extraction de calculs biliaires et drainage biliaire complet satisfaisant ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Embolisation hépatique
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chimio-embolisation hépatique ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### RTUP
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une résection trans-urétrale de prostate (RTUP) ?
+- **réponse** : Céfazoline
+
+### Prostatectomie totale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une prostatectomie totale ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Biopsie prostate transrectale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour des biopsies de prostate par voie transrectale ?
+- **réponse** : Fosfomycine-trométamol
+
+### Biopsie prostate transpérinéale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour des biopsies de prostate par voie transpérinéale ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Cystoscopie diagnostique
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une cystoscopie diagnostique ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Cystectomie sustrigonale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une cystectomie sustrigonale totale ?
+- **réponse** : Céfoxitine
+
+### Prothèse pénienne
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la pose d'une prothèse pénienne ?
+- **réponse** : Céfazoline
+
+### Chirurgie scrotale sans prothèse
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie scrotale sans prothèse ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Urétéroscopie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une urétéroscopie diagnostique ?
+- **réponse** : Céfazoline
+
+### Lithotritie extra-corporelle
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une lithotritie extra-corporelle ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Néphrolithotomie percutanée
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une néphrolithotomie percutanée ?
+- **réponse** : Céfazoline
+
 ---
 
 ## QCM
@@ -706,4 +892,59 @@ Pour les QCM, une seule réponse correcte (lettre).
   - B. Céfoxitine seule
   - C. Céfazoline + Métronidazole
   - D. Amoxicilline/Clavulanate
+- **réponse** : C
+
+### Bariatrique anneau vs sleeve
+
+- **type** : qcm
+- **question** : Concernant l'antibioprophylaxie en chirurgie bariatrique, quelle affirmation est correcte ?
+- **choix** :
+  - A. Anneau gastrique et sleeve gastrectomie utilisent la même molécule
+  - B. L'anneau gastrique nécessite de la céfazoline, la sleeve gastrectomie de la céfoxitine
+  - C. Aucune chirurgie bariatrique ne nécessite d'antibioprophylaxie
+  - D. Toute chirurgie bariatrique nécessite de la céfoxitine
+- **réponse** : B
+
+### Colectomie protocole ABP
+
+- **type** : qcm
+- **question** : Quel est le protocole d'antibioprophylaxie recommandé pour une colectomie programmée ?
+- **choix** :
+  - A. Céfoxitine IV le jour de la chirurgie uniquement
+  - B. Tobramycine + Métronidazole per os la veille, puis Céfoxitine IV le jour de la chirurgie
+  - C. Amoxicilline/Clavulanate IV le jour de la chirurgie uniquement
+  - D. Céfazoline IV le jour de la chirurgie + Métronidazole per os la veille
+- **réponse** : B
+
+### Cholécystectomie coelioscopique risque
+
+- **type** : qcm
+- **question** : Une cholécystectomie élective par coelioscopie est programmée. Dans quel cas une antibioprophylaxie est-elle recommandée ?
+- **choix** :
+  - A. Chez un patient de moins de 60 ans, sans comorbidité, pour vésicule lithiasique symptomatique sans cholecystite
+  - B. Chez un patient avec ictère et calcul de la voie biliaire principale
+  - C. Une antibioprophylaxie est toujours recommandée quelle que soit la situation
+  - D. Une antibioprophylaxie n'est jamais recommandée pour la voie coelioscopique
+- **réponse** : B
+
+### Biopsie prostate voie d'abord
+
+- **type** : qcm
+- **question** : Concernant l'antibioprophylaxie des biopsies de prostate, quelle affirmation est correcte ?
+- **choix** :
+  - A. Les deux voies (transrectale et transpérinéale) nécessitent une antibioprophylaxie
+  - B. Aucune des deux voies ne nécessite d'antibioprophylaxie
+  - C. Seule la voie transrectale nécessite une antibioprophylaxie (fosfomycine-trométamol)
+  - D. Seule la voie transpérinéale nécessite une antibioprophylaxie (céfazoline)
+- **réponse** : C
+
+### Hernie inguinale avec vs sans prothèse
+
+- **type** : qcm
+- **question** : Concernant l'antibioprophylaxie de la cure de hernie inguinale, quelle affirmation est correcte ?
+- **choix** :
+  - A. Une antibioprophylaxie est toujours recommandée, avec ou sans prothèse
+  - B. Une antibioprophylaxie n'est jamais recommandée, avec ou sans prothèse
+  - C. Une antibioprophylaxie est recommandée uniquement en cas de pose de prothèse
+  - D. Une antibioprophylaxie est recommandée uniquement en l'absence de prothèse
 - **réponse** : C

--- a/datasets/sfar_antibioprophylaxie/benchmark.md
+++ b/datasets/sfar_antibioprophylaxie/benchmark.md
@@ -386,6 +386,126 @@ Pour les QCM, une seule réponse correcte (lettre).
 - **question** : Quelle est la recommandation d'antibioprophylaxie pour une chondro-laryngoplastie par cervicotomie ?
 - **réponse** : Pas d'antibioprophylaxie
 
+### Tumorectomie mammaire avec curage axillaire
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une tumorectomie mammaire avec curage axillaire ?
+- **réponse** : Céfazoline
+
+### Mastoplastie de réduction
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une mastoplastie bilatérale de réduction ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Chirurgie du mamelon
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie du mamelon ou de la plaque aréolo-mamelonnaire ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Coelioscopie diagnostique gynécologique
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une coelioscopie diagnostique en gynécologie ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Annexectomie par coelioscopie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une annexectomie par voie coelioscopique ?
+- **réponse** : Céfazoline
+
+### Résection endométriose avec atteinte rectale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une résection de lésions endométriosiques avec atteinte rectale par coelioscopie ?
+- **réponse** : Céfazoline + Métronidazole
+
+### Hystérectomie totale par laparotomie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une hystérectomie totale sans annexectomie par laparotomie ?
+- **réponse** : Céfoxitine
+
+### Hystérectomie subtotale avec annexectomie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une hystérectomie subtotale avec annexectomie (sans temps vaginal) ?
+- **réponse** : Céfazoline
+
+### Conisation col utérin
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une conisation du col utérin ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Hystéroscopie diagnostique
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une hystéroscopie diagnostique ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Biopsie de l'endomètre
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une biopsie de l'endomètre par hystéroscopie ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Chirurgie du prolapsus
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une hystéropexie (chirurgie du prolapsus) ?
+- **réponse** : Céfazoline
+
+### Vulvectomie avec curage inguinal
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une vulvectomie partielle avec curage lymphonodal inguinal unilatéral ?
+- **réponse** : Céfazoline
+
+### Nymphoplastie de réduction
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une nymphoplastie de réduction ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Césarienne
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une césarienne programmée ?
+- **réponse** : Céfazoline
+
+### Cerclage col utérin grossesse
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour un cerclage du col de l'utérus au cours de la grossesse par voie transvaginale ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Révision utérine
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une révision de la cavité utérine après l'accouchement ?
+- **réponse** : Céfazoline
+
+### Tamponnement utérin hémorragie obstétricale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la pose d'un tamponnement intra-utérin pour hémorragie obstétricale ?
+- **réponse** : Céfazoline
+
+### IVG premier trimestre
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une interruption volontaire de grossesse par aspiration au premier trimestre ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Ponction ovocytes PMA
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour un prélèvement d'ovocytes par voie transvaginale avec échoguidage (PMA) ?
+- **réponse** : Pas d'antibioprophylaxie
+
 ---
 
 ## QCM
@@ -542,4 +662,48 @@ Pour les QCM, une seule réponse correcte (lettre).
   - B. Une antibioprophylaxie n'est jamais recommandée
   - C. Une antibioprophylaxie est recommandée uniquement en cas de greffe de cartilage
   - D. Une antibioprophylaxie est recommandée uniquement en cas de reprise chirurgicale
+- **réponse** : C
+
+### Hystérectomie voie d'abord et molécule
+
+- **type** : qcm
+- **question** : Quelle molécule est recommandée pour l'antibioprophylaxie d'une hystérectomie totale par voie coelioscopique (avec annexectomie) ?
+- **choix** :
+  - A. Céfazoline
+  - B. Céfoxitine
+  - C. Amoxicilline/Clavulanate
+  - D. Céfuroxime
+- **réponse** : B
+
+### Coelioscopie gynécologique sans ABP
+
+- **type** : qcm
+- **question** : Parmi ces interventions gynécologiques par coelioscopie, laquelle ne nécessite PAS d'antibioprophylaxie ?
+- **choix** :
+  - A. Annexectomie
+  - B. Curage pelvien
+  - C. Kystectomie ovarienne
+  - D. Omentectomie
+- **réponse** : C
+
+### Obstétrique césarienne vs cerclage
+
+- **type** : qcm
+- **question** : Concernant l'antibioprophylaxie en obstétrique, quelle affirmation est correcte ?
+- **choix** :
+  - A. Le cerclage du col utérin nécessite une antibioprophylaxie par céfazoline
+  - B. La césarienne programmée ne nécessite pas d'antibioprophylaxie
+  - C. La délivrance artificielle nécessite une antibioprophylaxie par céfazoline
+  - D. Le curetage post-partum nécessite une antibioprophylaxie par céfoxitine
+- **réponse** : C
+
+### Endométriose rectale molécule
+
+- **type** : qcm
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une résection de lésions endométriosiques avec atteinte rectale ?
+- **choix** :
+  - A. Céfazoline seule
+  - B. Céfoxitine seule
+  - C. Céfazoline + Métronidazole
+  - D. Amoxicilline/Clavulanate
 - **réponse** : C

--- a/datasets/sfar_antibioprophylaxie/benchmark.md
+++ b/datasets/sfar_antibioprophylaxie/benchmark.md
@@ -326,6 +326,66 @@ Pour les QCM, une seule réponse correcte (lettre).
 - **question** : Quelle est la recommandation d'antibioprophylaxie pour une œsophagectomie ?
 - **réponse** : Céfazoline
 
+### Pose prothèse mammaire
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une augmentation mammaire avec pose d'implants siliconés ?
+- **réponse** : Céfazoline
+
+### Tumorectomie mammaire sans curage
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une tumorectomie mammaire sans curage ganglionnaire ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Mastectomie sans reconstruction
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une mastectomie sans reconstruction mammaire ?
+- **réponse** : Céfazoline
+
+### Rhinoplastie sans greffe cartilage
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une septo-rhinoplastie sans greffe de cartilage ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Lipoaspiration
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une lipoaspiration sous anesthésie générale ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Blépharoplastie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une blépharoplastie ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Lambeau libre microchirurgical
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une reconstruction par lambeau libre microchirurgical ?
+- **réponse** : Céfazoline
+
+### Greffe cutanée hors brûlure
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une greffe cutanée (hors patient brûlé) ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Vaginoplastie affirmation de genre
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une vaginoplastie dans le cadre d'une chirurgie d'affirmation de genre ?
+- **réponse** : Amoxicilline/Clavulanate
+
+### Chondro-laryngoplastie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chondro-laryngoplastie par cervicotomie ?
+- **réponse** : Pas d'antibioprophylaxie
+
 ---
 
 ## QCM
@@ -440,8 +500,6 @@ Pour les QCM, une seule réponse correcte (lettre).
   - D. Une antibioprophylaxie est recommandée uniquement pour la trachéotomie percutanée
 - **réponse** : C
 
-### Assistance circulatoire et ABP
-
 ### Lobectomie pulmonaire molécule
 
 - **type** : qcm
@@ -461,5 +519,27 @@ Pour les QCM, une seule réponse correcte (lettre).
   - A. Une antibioprophylaxie est toujours recommandée
   - B. Une antibioprophylaxie n'est jamais recommandée
   - C. Une antibioprophylaxie est recommandée uniquement en cas de mise en place de matériel
+  - D. Une antibioprophylaxie est recommandée uniquement en cas de reprise chirurgicale
+- **réponse** : C
+
+### Chirurgie mammaire et ABP
+
+- **type** : qcm
+- **question** : Parmi ces interventions mammaires, laquelle nécessite une antibioprophylaxie ?
+- **choix** :
+  - A. Tumorectomie mammaire sans curage
+  - B. Mastopexie pour ptose simple
+  - C. Mastectomie sans curage ganglionnaire
+  - D. Réduction mammaire
+- **réponse** : C
+
+### Rhinoplastie avec vs sans greffe
+
+- **type** : qcm
+- **question** : Concernant l'antibioprophylaxie en septo-rhinoplastie, quelle affirmation est correcte ?
+- **choix** :
+  - A. Une antibioprophylaxie est toujours recommandée
+  - B. Une antibioprophylaxie n'est jamais recommandée
+  - C. Une antibioprophylaxie est recommandée uniquement en cas de greffe de cartilage
   - D. Une antibioprophylaxie est recommandée uniquement en cas de reprise chirurgicale
 - **réponse** : C

--- a/datasets/sfar_antibioprophylaxie/benchmark.md
+++ b/datasets/sfar_antibioprophylaxie/benchmark.md
@@ -320,12 +320,6 @@ Pour les QCM, une seule réponse correcte (lettre).
 - **question** : Quelle est la recommandation d'antibioprophylaxie pour une fibroscopie bronchique avec lavage broncho-alvéolaire ?
 - **réponse** : Pas d'antibioprophylaxie
 
-### Œsophagectomie
-
-- **type** : open
-- **question** : Quelle est la recommandation d'antibioprophylaxie pour une œsophagectomie ?
-- **réponse** : Céfazoline
-
 ### Pose prothèse mammaire
 
 - **type** : open

--- a/datasets/sfar_antibioprophylaxie/benchmark.md
+++ b/datasets/sfar_antibioprophylaxie/benchmark.md
@@ -781,7 +781,7 @@ Pour les QCM, une seule réponse correcte (lettre).
 ### Cataracte molécule
 
 - **type** : qcm
-- **question** : Quelle molécule est recommandée pour l'antibioprophylaxie de la chirurgie de la cataracte ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la chirurgie de la cataracte ?
 - **choix** :
   - A. Céfazoline IV
   - B. Céfuroxime intracamérulaire
@@ -847,7 +847,7 @@ Pour les QCM, une seule réponse correcte (lettre).
 ### Hystérectomie voie d'abord et molécule
 
 - **type** : qcm
-- **question** : Quelle molécule est recommandée pour l'antibioprophylaxie d'une hystérectomie totale par voie coelioscopique (avec annexectomie) ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une hystérectomie totale par voie coelioscopique (avec annexectomie) ?
 - **choix** :
   - A. Céfazoline
   - B. Céfoxitine
@@ -915,7 +915,7 @@ Pour les QCM, une seule réponse correcte (lettre).
 - **type** : qcm
 - **question** : Une cholécystectomie élective par coelioscopie est programmée. Dans quel cas une antibioprophylaxie est-elle recommandée ?
 - **choix** :
-  - A. Chez un patient de moins de 60 ans, sans comorbidité, pour vésicule lithiasique symptomatique sans cholecystite
+  - A. Chez un patient de moins de 60 ans, sans comorbidité, pour vésicule lithiasique symptomatique sans cholécystite
   - B. Chez un patient avec ictère et calcul de la voie biliaire principale
   - C. Une antibioprophylaxie est toujours recommandée quelle que soit la situation
   - D. Une antibioprophylaxie n'est jamais recommandée pour la voie coelioscopique

--- a/datasets/sfar_antibioprophylaxie/benchmark.md
+++ b/datasets/sfar_antibioprophylaxie/benchmark.md
@@ -254,6 +254,78 @@ Pour les QCM, une seule réponse correcte (lettre).
 - **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie carcinologique cervico-faciale avec lambeau chez un patient allergique aux bêtalactamines ?
 - **réponse** : Clindamycine + Gentamicine
 
+### Remplacement valvulaire sous CEC
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour un remplacement valvulaire aortique sous circulation extracorporelle (CEC) ?
+- **réponse** : Céfazoline
+
+### TAVI
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la pose d'une bioprothèse de valve aortique par voie transcutanée (TAVI) ?
+- **réponse** : Amoxicilline/Clavulanate
+
+### Pose pacemaker
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour l'implantation d'un stimulateur cardiaque (pacemaker) ?
+- **réponse** : Céfazoline
+
+### Ablation FA par cathéter
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une ablation de fibrillation atriale par cathéter (radiofréquence), chez un patient n'ayant pas de prothèse intracardiaque déjà implantée ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### ECMO percutanée
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la mise en place d'une ECMO percutanée (sans abord chirurgical) ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Endartériectomie carotidienne sans matériel
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une endartériectomie carotidienne sans mise en place de matériel ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Amputation de membre
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une amputation de membre (hors contexte septique) ?
+- **réponse** : Amoxicilline/Clavulanate
+
+### Chirurgie varices sans scarpa
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie des varices sans abord chirurgical du scarpa ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Drainage thoracique
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la pose d'un drain thoracique ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Médiastinoscopie avec biopsies
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une médiastinoscopie avec biopsies ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Fibroscopie bronchique
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une fibroscopie bronchique avec lavage broncho-alvéolaire ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Œsophagectomie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une œsophagectomie ?
+- **réponse** : Céfazoline
+
 ---
 
 ## QCM
@@ -366,4 +438,28 @@ Pour les QCM, une seule réponse correcte (lettre).
   - B. Aucune antibioprophylaxie n'est recommandée, quel que soit le type
   - C. Une antibioprophylaxie est recommandée uniquement pour la trachéotomie chirurgicale
   - D. Une antibioprophylaxie est recommandée uniquement pour la trachéotomie percutanée
+- **réponse** : C
+
+### Assistance circulatoire et ABP
+
+### Lobectomie pulmonaire molécule
+
+- **type** : qcm
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une lobectomie pulmonaire par thoracotomie ?
+- **choix** :
+  - A. Amoxicilline/Clavulanate uniquement
+  - B. Céfazoline uniquement
+  - C. Céfuroxime uniquement
+  - D. Amoxicilline/Clavulanate, Céfazoline ou Céfuroxime (au choix)
+- **réponse** : D
+
+### Carotide avec vs sans matériel
+
+- **type** : qcm
+- **question** : Concernant l'antibioprophylaxie de la chirurgie carotidienne, quelle affirmation est correcte ?
+- **choix** :
+  - A. Une antibioprophylaxie est toujours recommandée
+  - B. Une antibioprophylaxie n'est jamais recommandée
+  - C. Une antibioprophylaxie est recommandée uniquement en cas de mise en place de matériel
+  - D. Une antibioprophylaxie est recommandée uniquement en cas de reprise chirurgicale
 - **réponse** : C

--- a/datasets/sfar_antibioprophylaxie/benchmark.md
+++ b/datasets/sfar_antibioprophylaxie/benchmark.md
@@ -164,6 +164,96 @@ Pour les QCM, une seule réponse correcte (lettre).
 - **question** : Quelle est la recommandation d'antibioprophylaxie pour une plaie cranio-cérébrale chez un patient allergique aux pénicillines ?
 - **réponse** : Triméthoprime/Sulfaméthoxazole
 
+### Amygdalectomie
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une amygdalectomie ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Thyroïdectomie totale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une thyroïdectomie totale ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Chirurgie sinusienne polypose
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie sinusienne de polypose nasale ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Laryngectomie totale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une laryngectomie totale (chirurgie carcinologique ORL sans reconstruction) ?
+- **réponse** : Amoxicilline/Clavulanate
+
+### Implant cochléaire
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la pose d'un implant cochléaire ?
+- **réponse** : Céfazoline
+
+### Trachéotomie chirurgicale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une trachéotomie chirurgicale ?
+- **réponse** : Céfazoline
+
+### Trachéotomie percutanée
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une trachéotomie percutanée ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Chirurgie cataracte
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie de la cataracte ?
+- **réponse** : Céfuroxime
+
+### Chirurgie glaucome
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie du glaucome ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Traumatisme globe ouvert
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour un traumatisme à globe ouvert ?
+- **réponse** : Vancomycine + Ceftazidime
+
+### Chirurgie strabisme
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie du strabisme ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Extraction dent incluse
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour l'extraction d'une dent incluse ?
+- **réponse** : Amoxicilline
+
+### Fracture mandibule
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une fracture ouverte de mandibule ?
+- **réponse** : Amoxicilline/Clavulanate
+
+### Chirurgie orthognatique
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie orthognatique ?
+- **réponse** : Céfazoline
+
+### Carcinologique cervico-faciale allergie bêtalactamines
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une chirurgie carcinologique cervico-faciale avec lambeau chez un patient allergique aux bêtalactamines ?
+- **réponse** : Clindamycine + Gentamicine
+
 ---
 
 ## QCM
@@ -243,4 +333,37 @@ Pour les QCM, une seule réponse correcte (lettre).
   - B. Chirurgie du canal lombaire étroit
   - C. Arthrodèse instrumentée en un temps
   - D. Ablation de matériel du rachis
+- **réponse** : C
+
+### ORL sans ABP
+
+- **type** : qcm
+- **question** : Parmi ces interventions ORL, laquelle ne nécessite PAS d'antibioprophylaxie ?
+- **choix** :
+  - A. Pose d'implant cochléaire
+  - B. Amygdalectomie
+  - C. Laryngectomie totale
+  - D. Trachéotomie chirurgicale
+- **réponse** : B
+
+### Cataracte molécule
+
+- **type** : qcm
+- **question** : Quelle molécule est recommandée pour l'antibioprophylaxie de la chirurgie de la cataracte ?
+- **choix** :
+  - A. Céfazoline IV
+  - B. Céfuroxime intracamérulaire
+  - C. Vancomycine intravitréenne
+  - D. Moxifloxacine en collyre
+- **réponse** : B
+
+### Trachéotomie chirurgicale vs percutanée
+
+- **type** : qcm
+- **question** : Concernant l'antibioprophylaxie des trachéotomies, quelle affirmation est correcte ?
+- **choix** :
+  - A. Une antibioprophylaxie est recommandée pour les deux types de trachéotomie
+  - B. Aucune antibioprophylaxie n'est recommandée, quel que soit le type
+  - C. Une antibioprophylaxie est recommandée uniquement pour la trachéotomie chirurgicale
+  - D. Une antibioprophylaxie est recommandée uniquement pour la trachéotomie percutanée
 - **réponse** : C

--- a/datasets/sfar_antibioprophylaxie/benchmark.md
+++ b/datasets/sfar_antibioprophylaxie/benchmark.md
@@ -23,7 +23,7 @@ Pour les QCM, une seule réponse correcte (lettre).
 ### PTH standard
 
 - **type** : open
-- **question** : Quelle molécule d'antibioprophylaxie recommandez-vous pour une prothèse totale de hanche ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une prothèse totale de hanche ?
 - **réponse** : Céfazoline
 
 ### Arthroscopie genou diagnostique
@@ -35,19 +35,19 @@ Pour les QCM, une seule réponse correcte (lettre).
 ### PTG allergie bêtalactamines
 
 - **type** : open
-- **question** : Un patient allergique aux bêtalactamines doit bénéficier d'une prothèse de genou. Quelle molécule en première intention ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une prothèse totale de genou chez un patient allergique aux bêtalactamines ?
 - **réponse** : Clindamycine
 
 ### PTH voie antérieure allergie
 
 - **type** : open
-- **question** : Quelle molécule d'antibioprophylaxie pour une prothèse de hanche par voie antérieure chez un patient allergique aux bêtalactamines ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une prothèse de hanche par voie antérieure chez un patient allergique aux bêtalactamines ?
 - **réponse** : Vancomycine
 
 ### Fracture ouverte Gustilo 2
 
 - **type** : open
-- **question** : Quelle molécule d'antibioprophylaxie pour une fracture ouverte de jambe Gustilo 2 ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une fracture ouverte de jambe Gustilo 2 ?
 - **réponse** : Amoxicilline/Clavulanate
 
 ### Fixateur externe fracture fermée
@@ -59,25 +59,25 @@ Pour les QCM, une seule réponse correcte (lettre).
 ### Arthrodèse lombaire instrumentée
 
 - **type** : open
-- **question** : Quelle molécule d'antibioprophylaxie pour une arthrodèse lombaire instrumentée en un temps ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une arthrodèse lombaire instrumentée en un temps ?
 - **réponse** : Céfazoline
 
 ### Parage morsure
 
 - **type** : open
-- **question** : Quelle molécule d'antibioprophylaxie pour le parage chirurgical d'une morsure ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour le parage chirurgical d'une morsure ?
 - **réponse** : Amoxicilline/Clavulanate
 
 ### Écrasement main > 2h
 
 - **type** : open
-- **question** : Quelle molécule d'antibioprophylaxie pour un écrasement complexe de la main nécessitant une chirurgie de plus de 2 heures ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour un écrasement complexe de la main nécessitant une chirurgie de plus de 2 heures ?
 - **réponse** : Amoxicilline/Clavulanate
 
 ### Plaie agricole cuisse
 
 - **type** : open
-- **question** : Quelle molécule d'antibioprophylaxie pour une plaie de cuisse par accident agricole, susceptible d'être contaminée par des germes telluriques ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une plaie de cuisse par accident agricole, susceptible d'être contaminée par des germes telluriques ?
 - **réponse** : Amoxicilline/Clavulanate
 
 ### Plaie simple mollet
@@ -89,7 +89,7 @@ Pour les QCM, une seule réponse correcte (lettre).
 ### Fracture ouverte Gustilo 3 allergie
 
 - **type** : open
-- **question** : Un patient allergique aux pénicillines présente une fracture ouverte Gustilo 3. Quelle(s) molécule(s) d'antibioprophylaxie ?
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une fracture ouverte Gustilo 3 chez un patient allergique aux pénicillines ?
 - **réponse** : Clindamycine + Gentamicine
 
 ### Ablation matériel ostéosynthèse MI
@@ -97,6 +97,72 @@ Pour les QCM, une seule réponse correcte (lettre).
 - **type** : open
 - **question** : Quelle est la recommandation d'antibioprophylaxie pour l'ablation de matériel d'ostéosynthèse au membre inférieur ?
 - **réponse** : Pas d'antibioprophylaxie
+
+### Craniotomie standard
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une craniotomie ?
+- **réponse** : Céfazoline
+
+### Biopsie cérébrale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une biopsie cérébrale ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### DVE
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la pose d'une dérivation ventriculaire externe (DVE) ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### DVP
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la pose d'une dérivation ventriculo-péritonéale (DVP) ?
+- **réponse** : Céfazoline
+
+### Plaie cranio-cérébrale
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une plaie cranio-cérébrale pénétrante ?
+- **réponse** : Amoxicilline/Clavulanate
+
+### Fracture base du crâne sans otorrhée
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une fracture de la base du crâne sans otorrhée ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Fracture base du crâne avec otorrhée
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une fracture de la base du crâne avec otorrhée ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Pose stimulateur cérébral
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour la pose d'une électrode de stimulation cérébrale profonde ?
+- **réponse** : Céfazoline
+
+### Embolisation anévrysme cérébral
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour l'embolisation d'un anévrysme cérébral ?
+- **réponse** : Pas d'antibioprophylaxie
+
+### Craniotomie allergie bêtalactamines
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une craniotomie chez un patient allergique aux bêtalactamines ?
+- **réponse** : Clindamycine
+
+### Plaie cranio-cérébrale allergie pénicillines
+
+- **type** : open
+- **question** : Quelle est la recommandation d'antibioprophylaxie pour une plaie cranio-cérébrale chez un patient allergique aux pénicillines ?
+- **réponse** : Triméthoprime/Sulfaméthoxazole
 
 ---
 
@@ -155,4 +221,26 @@ Pour les QCM, une seule réponse correcte (lettre).
   - B. Amoxicilline/Clavulanate 2g IVL
   - C. Pas d'antibioprophylaxie recommandée
   - D. Clindamycine 900mg IVL
+- **réponse** : C
+
+### DVE vs DVP
+
+- **type** : qcm
+- **question** : Parmi ces actes neurochirurgicaux, lequel nécessite une antibioprophylaxie ?
+- **choix** :
+  - A. Dérivation ventriculaire externe (DVE)
+  - B. Biopsie cérébrale
+  - C. Dérivation ventriculo-péritonéale (DVP)
+  - D. Angiographie des artères cérébrales
+- **réponse** : C
+
+### Rachis avec vs sans matériel
+
+- **type** : qcm
+- **question** : Pour la chirurgie du rachis, dans quel cas une antibioprophylaxie est-elle recommandée ?
+- **choix** :
+  - A. Laminectomie sans pose de matériel
+  - B. Chirurgie du canal lombaire étroit
+  - C. Arthrodèse instrumentée en un temps
+  - D. Ablation de matériel du rachis
 - **réponse** : C


### PR DESCRIPTION
## Summary
- Ajout de **119 nouvelles questions** (99 ouvertes + 20 QCM) au benchmark d'antibioprophylaxie, portant le total à **135 questions** (112 open + 23 QCM)
- Couverture des 8 parties adultes des RFE SFAR 2024 : neurochirurgie, ORL/ophtalmo/maxillo-faciale, cardiaque/vasculaire/thoracique, plastique/reconstructrice/brûlé, gynécologie/obstétrique/PMA, digestive/bariatrique/endoscopie, urologie
- Neutralisation de toutes les formulations de questions ("Quelle est la recommandation d'antibioprophylaxie pour..." au lieu de "Faut-il..." ou "Quelle molécule...")

## Test plan
- [ ] `uv run python datasets/sfar_antibioprophylaxie/md_to_json.py` compile sans erreur
- [ ] `uv run pytest` passe
- [ ] `uv run ruff check .` propre
- [ ] Lancer un benchmark sur un modèle pour valider le scoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Mise à jour et reformulation de questions cliniques existantes avec nouvelles variantes contextuelles
  * Ajout de nombreuses questions couvrant des domaines chirurgicaux supplémentaires (neurochirurgie, ORL, ophtalmologie, urologie, etc.)
  * Expansion de la base de données avec de nouvelles recommandations d'antibioprophylaxie et leurs réponses associées

<!-- end of auto-generated comment: release notes by coderabbit.ai -->